### PR TITLE
feat: implement dashboard page with metrics and translate UI to Portuguese

### DIFF
--- a/app/[locale]/(logged)/brand/page.tsx
+++ b/app/[locale]/(logged)/brand/page.tsx
@@ -28,12 +28,12 @@ export default function BrandDnaPage() {
   const [sliders, setSliders] = useState<TonalitySlider[]>(DEFAULT_TONALITY)
   const [colors, setColors] = useState<BrandColor[]>(DEFAULT_COLORS)
   const [fonts, setFonts] = useState<FontSelection[]>(DEFAULT_FONTS)
-  const [persona, setPersona] = useState('The Visionary Architect')
+  const [persona, setPersona] = useState('O Arquiteto Visionario')
   const [alwaysUse, setAlwaysUse] = useState(
-    'Active verbs, kinetic metaphors, editorial pacing.',
+    'Verbos ativos, metaforas cineticas, ritmo editorial.',
   )
   const [neverUse, setNeverUse] = useState(
-    'Buzzwords, emojis in headlines, passive voice.',
+    'Jargoes, emojis em titulos, voz passiva.',
   )
 
   const handleSliderChange = useCallback((id: string, value: number) => {
@@ -67,12 +67,12 @@ export default function BrandDnaPage() {
           <section className="rounded-xl border border-outline-variant/10 bg-surface-container p-8 shadow-sm">
             <div className="mb-8 flex items-center justify-between">
               <h3 className="text-sm font-bold uppercase tracking-widest text-secondary">
-                Voice DNA & Tonality
+                Voz DNA & Tonalidade
               </h3>
               <div className="flex items-center gap-2">
                 <div className="h-2 w-2 animate-pulse rounded-full bg-tertiary shadow-[0_0_8px_#ffb148]" />
                 <span className="text-[10px] font-bold uppercase tracking-widest text-on-surface-variant">
-                  AI Engine Active
+                  Motor IA Ativo
                 </span>
               </div>
             </div>

--- a/app/[locale]/(logged)/create/page.tsx
+++ b/app/[locale]/(logged)/create/page.tsx
@@ -29,7 +29,7 @@ export default function CreateContentPage() {
 
   return (
     <div className="flex-1 px-6 pb-24 pt-12 md:px-8">
-      <div className="mx-auto w-full max-w-6xl">
+      <div className="w-full max-w-6xl">
         <CreationHeader />
 
         <CreationTabs activeTab={activeTab} onTabChange={setActiveTab} />

--- a/app/[locale]/(logged)/dashboard/page.tsx
+++ b/app/[locale]/(logged)/dashboard/page.tsx
@@ -1,0 +1,38 @@
+import {
+  WelcomeHero,
+  StatsRow,
+  NextScheduledCard,
+  RecentContentTable,
+  PerformanceCard,
+  QuickActionBar,
+} from '@modules/dashboard/application/components'
+import {
+  MOCK_STATS,
+  MOCK_RECENT_CONTENT,
+  MOCK_PERFORMANCE,
+} from '@modules/dashboard/application/mock-data'
+
+export default function DashboardPage() {
+  return (
+    <div className="flex-1 overflow-y-auto p-6 pb-28 no-scrollbar lg:p-8">
+      <div className="space-y-12">
+        <WelcomeHero />
+
+        <StatsRow stats={MOCK_STATS} />
+
+        <div className="grid grid-cols-1 gap-8 lg:grid-cols-3">
+          <div className="space-y-8 lg:col-span-2">
+            <NextScheduledCard />
+            <RecentContentTable items={MOCK_RECENT_CONTENT} />
+          </div>
+
+          <div>
+            <PerformanceCard metrics={MOCK_PERFORMANCE} />
+          </div>
+        </div>
+      </div>
+
+      <QuickActionBar />
+    </div>
+  )
+}

--- a/src/modules/brand-dna/application/components/brand-page-header.tsx
+++ b/src/modules/brand-dna/application/components/brand-page-header.tsx
@@ -2,12 +2,12 @@ export function BrandPageHeader() {
   return (
     <header className="mb-12">
       <h2 className="mb-2 text-4xl font-black tracking-tighter text-on-surface">
-        Brand Identity System
+        Sistema de Identidade da Marca
       </h2>
       <p className="max-w-2xl leading-relaxed text-on-surface-variant">
-        Define the kinetic soul of Infinity Creators. This data fuels our
-        generative engines to ensure absolute consistency across every
-        touchpoint.
+        Defina a alma criativa do Infinity Creators. Esses dados alimentam
+        nossos motores generativos para garantir consistencia absoluta em
+        todos os pontos de contato.
       </p>
     </header>
   )

--- a/src/modules/brand-dna/application/components/color-palette.tsx
+++ b/src/modules/brand-dna/application/components/color-palette.tsx
@@ -11,9 +11,9 @@ interface ColorPaletteProps {
 }
 
 function contrastText(hex: string): string {
-  const r = parseInt(hex.slice(1, 3), 16)
-  const g = parseInt(hex.slice(3, 5), 16)
-  const b = parseInt(hex.slice(5, 7), 16)
+  const r = Number.parseInt(hex.slice(1, 3), 16)
+  const g = Number.parseInt(hex.slice(3, 5), 16)
+  const b = Number.parseInt(hex.slice(5, 7), 16)
   const luminance = (0.299 * r + 0.587 * g + 0.114 * b) / 255
   return luminance > 0.5 ? '#1a1a1d' : '#f9f5f8'
 }
@@ -122,7 +122,7 @@ function HexInput({
         onClick={handleSubmit}
         className="rounded-lg bg-surface-bright px-3 py-2 text-xs font-bold text-on-surface transition-colors hover:bg-primary hover:text-on-surface"
       >
-        Add
+        Adicionar
       </button>
     </div>
   )
@@ -148,7 +148,7 @@ function PaletteSuggestions({
   }, [shuffleKey])
 
   function handleApply(paletteColors: string[]) {
-    const labels = ['Primary', 'Secondary', 'Accent', 'Highlight', 'Base']
+    const labels = ['Primaria', 'Secundaria', 'Destaque', 'Realce', 'Base']
     onApply(
       paletteColors.map((hex, i) => ({
         id: crypto.randomUUID(),
@@ -162,7 +162,7 @@ function PaletteSuggestions({
     <div className="space-y-3">
       <div className="flex items-center justify-between">
         <p className="text-[10px] font-bold uppercase tracking-widest text-on-surface-variant">
-          Or pick a preset
+          Ou escolha um preset
         </p>
         <button
           type="button"
@@ -170,7 +170,7 @@ function PaletteSuggestions({
           className="flex items-center gap-1 text-[10px] font-bold uppercase tracking-widest text-on-surface-variant transition-colors hover:text-on-surface"
         >
           <RefreshCw size={10} />
-          Shuffle
+          Embaralhar
         </button>
       </div>
       <div className="grid grid-cols-2 gap-2">
@@ -214,7 +214,7 @@ export function ColorPalette({ colors, onColorsChange }: Readonly<ColorPalettePr
   function handleAdd(hex: string) {
     const newColor: BrandColor = {
       id: crypto.randomUUID(),
-      label: `Color ${colors.length + 1}`,
+      label: `Cor ${colors.length + 1}`,
       hex,
     }
     onColorsChange([...colors, newColor])
@@ -223,7 +223,7 @@ export function ColorPalette({ colors, onColorsChange }: Readonly<ColorPalettePr
   function handleAddViaColorPicker() {
     const newColor: BrandColor = {
       id: crypto.randomUUID(),
-      label: `Color ${colors.length + 1}`,
+      label: `Cor ${colors.length + 1}`,
       hex: '#6366f1',
     }
     onColorsChange([...colors, newColor])
@@ -233,10 +233,10 @@ export function ColorPalette({ colors, onColorsChange }: Readonly<ColorPalettePr
     <section className="rounded-xl border border-outline-variant/10 bg-surface-container p-8 shadow-sm">
       <div className="mb-6 flex items-center justify-between">
         <h3 className="text-sm font-bold uppercase tracking-widest text-primary">
-          Color Palette
+          Paleta de Cores
         </h3>
         <span className="text-[10px] text-on-surface-variant">
-          {colors.length} color{colors.length !== 1 ? 's' : ''}
+          {colors.length} {colors.length !== 1 ? 'cores' : 'cor'}
         </span>
       </div>
 
@@ -257,7 +257,7 @@ export function ColorPalette({ colors, onColorsChange }: Readonly<ColorPalettePr
         >
           <Plus size={16} className="mb-1 text-on-surface-variant" />
           <span className="text-[9px] font-bold uppercase tracking-widest text-on-surface-variant">
-            Add Color
+            Adicionar
           </span>
         </button>
       </div>
@@ -271,7 +271,7 @@ export function ColorPalette({ colors, onColorsChange }: Readonly<ColorPalettePr
           className="flex w-full items-center justify-between text-on-surface-variant transition-colors hover:text-on-surface"
         >
           <span className="text-[10px] font-bold uppercase tracking-[0.2em]">
-            Palette Suggestions
+            Sugestoes de Paleta
           </span>
           <ChevronDown
             size={14}

--- a/src/modules/brand-dna/application/components/logo-upload.tsx
+++ b/src/modules/brand-dna/application/components/logo-upload.tsx
@@ -5,7 +5,7 @@ export function LogoUpload() {
     <section className="rounded-xl border border-outline-variant/10 bg-surface-container p-8 shadow-sm">
       <div className="mb-6 flex items-center justify-between">
         <h3 className="text-sm font-bold uppercase tracking-widest text-primary">
-          Master Logo
+          Logo Principal
         </h3>
         <Upload size={20} className="text-on-surface-variant" />
       </div>
@@ -15,10 +15,10 @@ export function LogoUpload() {
           <Plus size={28} className="text-primary" />
         </div>
         <p className="text-sm font-medium text-on-surface">
-          Drop brand assets here
+          Arraste os assets da marca aqui
         </p>
         <p className="mt-1 text-xs text-on-surface-variant">
-          SVG, PNG or AI (Max 20MB)
+          SVG, PNG ou AI (Max 20MB)
         </p>
       </div>
     </section>

--- a/src/modules/brand-dna/application/components/persona-input.tsx
+++ b/src/modules/brand-dna/application/components/persona-input.tsx
@@ -12,7 +12,7 @@ export function PersonaInput({ value, onChange }: Readonly<PersonaInputProps>) {
         htmlFor="persona-input"
         className="mb-3 block text-[10px] font-bold uppercase tracking-widest text-on-surface-variant"
       >
-        Persona / Primary Author
+        Persona / Autor Principal
       </label>
       <input
         id="persona-input"

--- a/src/modules/brand-dna/application/components/reference-posts.tsx
+++ b/src/modules/brand-dna/application/components/reference-posts.tsx
@@ -14,7 +14,7 @@ export function ReferencePosts({ posts }: Readonly<ReferencePostsProps>) {
   return (
     <div>
       <p className="mb-4 text-[10px] font-bold uppercase tracking-widest text-on-surface-variant">
-        Gold Standard References
+        Referencias de Ouro
       </p>
 
       <div className="space-y-3">

--- a/src/modules/brand-dna/application/components/save-bar.tsx
+++ b/src/modules/brand-dna/application/components/save-bar.tsx
@@ -10,7 +10,7 @@ export function SaveBar() {
           </div>
           <div>
             <p className="text-xs font-bold text-on-surface">
-              Auto-saved to Cloud
+              Salvo automaticamente
             </p>
             <p className="text-[10px] text-on-surface-variant">
               Infinity Creators DNA v1.0.4
@@ -23,13 +23,13 @@ export function SaveBar() {
             type="button"
             className="rounded-xl px-6 py-2.5 text-sm font-bold text-on-surface transition-colors hover:bg-surface-bright"
           >
-            Discard
+            Descartar
           </button>
           <button
             type="button"
             className="brand-gradient rounded-xl px-8 py-2.5 text-sm font-bold text-on-surface shadow-lg shadow-primary/20 transition-all active:scale-95"
           >
-            Publish DNA Changes
+            Publicar Alteracoes
           </button>
         </div>
       </div>

--- a/src/modules/brand-dna/application/components/typography-preview.tsx
+++ b/src/modules/brand-dna/application/components/typography-preview.tsx
@@ -64,7 +64,7 @@ function FontDropdown({
               type="text"
               value={search}
               onChange={(e) => setSearch(e.target.value)}
-              placeholder="Search fonts..."
+              placeholder="Buscar fontes..."
               className="flex-1 border-none bg-transparent text-xs text-on-surface placeholder:text-on-surface-variant/50 focus:outline-none focus:ring-0"
             />
           </div>
@@ -90,7 +90,7 @@ function FontDropdown({
             ))}
             {filtered.length === 0 && (
               <p className="px-3 py-2 text-xs text-on-surface-variant">
-                No fonts found for &quot;{search}&quot;
+                Nenhuma fonte encontrada para &quot;{search}&quot;
               </p>
             )}
           </div>
@@ -98,7 +98,7 @@ function FontDropdown({
           <div className="border-t border-outline-variant/10 pt-2">
             <label className="flex cursor-pointer items-center gap-2 rounded-lg border border-dashed border-outline-variant/20 px-3 py-2 text-xs text-on-surface-variant transition-colors hover:border-primary/50 hover:text-on-surface">
               <Upload size={12} />
-              <span>Upload font (.ttf, .otf, .woff2)</span>
+              <span>Enviar fonte (.ttf, .otf, .woff2)</span>
               <input
                 type="file"
                 accept=".ttf,.otf,.woff,.woff2"
@@ -122,7 +122,7 @@ function FontDropdown({
 
 export function TypographyPreview({ fonts, onFontChange }: Readonly<TypographyPreviewProps>) {
   const [previewText, setPreviewText] = useState(
-    'Type something to preview your brand typography...',
+    'Digite algo para visualizar a tipografia da sua marca...',
   )
 
   const headlineFont = fonts.find((f) => f.role === 'headline')
@@ -132,13 +132,13 @@ export function TypographyPreview({ fonts, onFontChange }: Readonly<TypographyPr
     <section className="rounded-xl border border-outline-variant/10 bg-surface-container p-8 shadow-sm">
       <div className="mb-6 flex items-center justify-between">
         <h3 className="text-sm font-bold uppercase tracking-widest text-primary">
-          Typography
+          Tipografia
         </h3>
         <div className="flex items-center gap-3">
           {headlineFont && (
             <div className="flex items-center gap-2">
               <span className="text-[10px] font-bold uppercase tracking-widest text-on-surface-variant">
-                Headline
+                Titulo
               </span>
               <FontDropdown
                 font={headlineFont}
@@ -149,7 +149,7 @@ export function TypographyPreview({ fonts, onFontChange }: Readonly<TypographyPr
           {bodyFont && (
             <div className="flex items-center gap-2">
               <span className="text-[10px] font-bold uppercase tracking-widest text-on-surface-variant">
-                Body
+                Corpo
               </span>
               <FontDropdown
                 font={bodyFont}
@@ -167,7 +167,7 @@ export function TypographyPreview({ fonts, onFontChange }: Readonly<TypographyPr
           type="text"
           value={previewText}
           onChange={(e) => setPreviewText(e.target.value)}
-          placeholder="Type to preview..."
+          placeholder="Digite para visualizar..."
           className="flex-1 border-none bg-transparent text-sm text-on-surface placeholder:text-on-surface-variant/50 focus:outline-none focus:ring-0"
         />
       </div>
@@ -176,19 +176,19 @@ export function TypographyPreview({ fonts, onFontChange }: Readonly<TypographyPr
       <div className="space-y-4 rounded-lg bg-surface-container-low p-6">
         <div>
           <p className="mb-1 text-[10px] font-bold uppercase tracking-widest text-on-surface-variant">
-            Headline &middot; {headlineFont?.fontName ?? 'Inter'} Black
+            Titulo &middot; {headlineFont?.fontName ?? 'Inter'} Black
           </p>
           <p className="text-3xl font-black leading-tight tracking-tight text-on-surface">
-            {previewText || 'Type something to preview...'}
+            {previewText || 'Digite algo para visualizar...'}
           </p>
         </div>
 
         <div className="border-t border-outline-variant/10 pt-4">
           <p className="mb-1 text-[10px] font-bold uppercase tracking-widest text-on-surface-variant">
-            Body &middot; {bodyFont?.fontName ?? 'Inter'} Regular
+            Corpo &middot; {bodyFont?.fontName ?? 'Inter'} Regular
           </p>
           <p className="text-base font-normal leading-relaxed text-on-surface">
-            {previewText || 'Type something to preview...'}
+            {previewText || 'Digite algo para visualizar...'}
           </p>
         </div>
       </div>

--- a/src/modules/brand-dna/application/components/writing-rules.tsx
+++ b/src/modules/brand-dna/application/components/writing-rules.tsx
@@ -23,7 +23,7 @@ export function WritingRules({
           className="flex items-center text-[10px] font-bold uppercase tracking-widest text-on-surface-variant"
         >
           <CheckCircle size={12} className="mr-2 text-tertiary" />
-          Always Use
+          Sempre Usar
         </label>
         <textarea
           id="always-use"
@@ -39,7 +39,7 @@ export function WritingRules({
           className="flex items-center text-[10px] font-bold uppercase tracking-widest text-on-surface-variant"
         >
           <XCircle size={12} className="mr-2 text-error" />
-          Never Use
+          Nunca Usar
         </label>
         <textarea
           id="never-use"

--- a/src/modules/brand-dna/application/types.ts
+++ b/src/modules/brand-dna/application/types.ts
@@ -92,23 +92,23 @@ export const PALETTE_PRESETS: PalettePreset[] = [
 
 export const DEFAULT_TONALITY: TonalitySlider[] = [
   { id: 'formality', labelLeft: 'Formal', labelRight: 'Casual', value: 65 },
-  { id: 'professionalism', labelLeft: 'Professional', labelRight: 'Witty', value: 30 },
-  { id: 'detail', labelLeft: 'Minimalist', labelRight: 'Detailed', value: 80 },
+  { id: 'professionalism', labelLeft: 'Profissional', labelRight: 'Espirituoso', value: 30 },
+  { id: 'detail', labelLeft: 'Minimalista', labelRight: 'Detalhado', value: 80 },
 ]
 
 export const DEFAULT_REFERENCES: ReferencePost[] = [
   {
     id: '1',
-    title: 'Manifesto: The Future of Creator Tech',
-    source: 'Linked via Notion',
-    lastUpdated: 'Last updated 2d ago',
+    title: 'Manifesto: O Futuro da Tecnologia para Criadores',
+    source: 'Vinculado via Notion',
+    lastUpdated: 'Atualizado ha 2 dias',
     icon: 'article',
   },
   {
     id: '2',
-    title: 'Twitter Thread: Rebranding Infinity',
-    source: 'Imported from X',
-    lastUpdated: 'Last updated 1w ago',
+    title: 'Thread no X: Rebranding Infinity',
+    source: 'Importado do X',
+    lastUpdated: 'Atualizado ha 1 semana',
     icon: 'campaign',
   },
 ]

--- a/src/modules/create-content/application/components/advanced-parameters.tsx
+++ b/src/modules/create-content/application/components/advanced-parameters.tsx
@@ -14,7 +14,7 @@ export function AdvancedParameters() {
         className="flex w-full items-center justify-between text-on-surface-variant transition-colors hover:text-on-surface"
       >
         <span className="text-[10px] font-bold uppercase tracking-[0.2em]">
-          Advanced Parameters
+          Parametros Avancados
         </span>
         <ChevronDown
           size={18}
@@ -25,7 +25,7 @@ export function AdvancedParameters() {
       {isOpen && (
         <div className="mt-6 space-y-4 border-t border-outline-variant/15 pt-6">
           <p className="text-xs text-on-surface-variant">
-            Advanced configuration options coming soon.
+            Opcoes de configuracao avancada em breve.
           </p>
         </div>
       )}

--- a/src/modules/create-content/application/components/content-input-card.tsx
+++ b/src/modules/create-content/application/components/content-input-card.tsx
@@ -15,7 +15,7 @@ export function ContentInputCard({ value, onChange }: Readonly<ContentInputCardP
     <div className="col-span-12 lg:col-span-8">
       <div className="flex min-h-[400px] flex-col rounded-xl bg-surface-container p-8 ghost-border">
         <label htmlFor="content-input" className="mb-4 text-[10px] font-bold uppercase tracking-[0.2em] text-on-surface-variant">
-          Input Context & Details
+          Contexto & Detalhes
         </label>
 
         <textarea
@@ -24,7 +24,7 @@ export function ContentInputCard({ value, onChange }: Readonly<ContentInputCardP
           onChange={(e) => onChange(e.target.value)}
           maxLength={MAX_TOKENS}
           className="flex-1 resize-none border-none bg-transparent text-xl font-medium leading-relaxed text-on-surface placeholder:text-surface-bright focus:ring-0 focus:outline-none"
-          placeholder="What are we building today? Paste a changelog, share a raw idea, or describe the vibe of your next viral post..."
+          placeholder="O que vamos criar hoje? Cole um changelog, compartilhe uma ideia crua, ou descreva o vibe do seu proximo post viral..."
         />
 
         <div className="mt-8 flex items-center justify-between border-t border-outline-variant/15 pt-8">
@@ -34,14 +34,14 @@ export function ContentInputCard({ value, onChange }: Readonly<ContentInputCardP
               className="flex items-center gap-2 text-xs font-bold text-on-surface-variant transition-colors hover:text-primary"
             >
               <Paperclip size={14} />
-              <span>ATTACH ASSETS</span>
+              <span>ANEXAR ARQUIVOS</span>
             </button>
             <button
               type="button"
               className="flex items-center gap-2 text-xs font-bold text-on-surface-variant transition-colors hover:text-primary"
             >
               <Wand2 size={14} />
-              <span>ENHANCE PROMPT</span>
+              <span>MELHORAR PROMPT</span>
             </button>
           </div>
           <span className="font-mono text-xs uppercase text-on-surface-variant">

--- a/src/modules/create-content/application/components/creation-header.tsx
+++ b/src/modules/create-content/application/components/creation-header.tsx
@@ -4,12 +4,12 @@ export function CreationHeader() {
       <div className="mb-2 flex items-center gap-3">
         <div className="h-2 w-2 rounded-full bg-tertiary pulse-orb" />
         <span className="text-[10px] font-bold uppercase tracking-[0.3em] text-tertiary">
-          New Creation Session
+          Nova Sessao Criativa
         </span>
       </div>
       <h2 className="text-5xl font-black leading-tight tracking-tight text-on-surface">
-        Bring your ideas <br />
-        <span className="text-primary">to life.</span>
+        De vida as suas <br />
+        <span className="text-primary">ideias.</span>
       </h2>
     </div>
   )

--- a/src/modules/create-content/application/components/floating-assistant.tsx
+++ b/src/modules/create-content/application/components/floating-assistant.tsx
@@ -3,12 +3,12 @@ export function FloatingAssistant() {
     <div className="fixed bottom-8 right-8 z-100">
       <button
         type="button"
-        aria-label="System assistant"
+        aria-label="Assistente do sistema"
         className="glass ghost-border group flex h-14 w-14 items-center justify-center rounded-full shadow-2xl transition-all hover:border-primary/50"
       >
         <div className="h-3 w-3 rounded-full bg-tertiary pulse-orb transition-transform group-hover:scale-125" />
         <div className="ghost-border absolute -top-12 right-0 whitespace-nowrap rounded-lg bg-surface-bright px-3 py-1 text-[10px] font-bold uppercase tracking-widest opacity-0 transition-opacity group-hover:opacity-100">
-          System Active
+          Sistema Ativo
         </div>
       </button>
     </div>

--- a/src/modules/create-content/application/components/platform-selector.tsx
+++ b/src/modules/create-content/application/components/platform-selector.tsx
@@ -19,7 +19,7 @@ export function PlatformSelector({ selected, onToggle }: PlatformSelectorProps) 
   return (
     <div className="rounded-xl bg-surface-container p-6 ghost-border">
       <label className="mb-6 block text-[10px] font-bold uppercase tracking-[0.2em] text-on-surface-variant">
-        Target Platforms
+        Plataformas Alvo
       </label>
 
       <div className="grid grid-cols-2 gap-3">

--- a/src/modules/create-content/application/components/tone-selector.tsx
+++ b/src/modules/create-content/application/components/tone-selector.tsx
@@ -15,7 +15,7 @@ export function ToneSelector({ value, onChange }: ToneSelectorProps) {
         htmlFor="tone-select"
         className="mb-4 block text-[10px] font-bold uppercase tracking-[0.2em] text-on-surface-variant"
       >
-        Persona & Tone
+        Persona & Tom
       </label>
       <select
         id="tone-select"

--- a/src/modules/create-content/application/types.ts
+++ b/src/modules/create-content/application/types.ts
@@ -14,10 +14,10 @@ export interface ToneOption {
 }
 
 export const TONE_OPTIONS: ToneOption[] = [
-  { value: 'editorial-authority', label: 'Editorial Authority' },
-  { value: 'hype', label: 'Hype / High Energy' },
-  { value: 'minimalist', label: 'Minimalist / Stoic' },
-  { value: 'technical', label: 'Technical / Deep Dive' },
+  { value: 'editorial-authority', label: 'Autoridade Editorial' },
+  { value: 'hype', label: 'Hype / Alta Energia' },
+  { value: 'minimalist', label: 'Minimalista / Estoico' },
+  { value: 'technical', label: 'Tecnico / Deep Dive' },
 ]
 
 export const MAX_TOKENS = 2500

--- a/src/modules/dashboard/application/components/index.ts
+++ b/src/modules/dashboard/application/components/index.ts
@@ -1,0 +1,6 @@
+export { WelcomeHero } from './welcome-hero'
+export { StatsRow } from './stats-row'
+export { NextScheduledCard } from './next-scheduled-card'
+export { RecentContentTable } from './recent-content-table'
+export { PerformanceCard } from './performance-card'
+export { QuickActionBar } from './quick-action-bar'

--- a/src/modules/dashboard/application/components/next-scheduled-card.tsx
+++ b/src/modules/dashboard/application/components/next-scheduled-card.tsx
@@ -1,0 +1,45 @@
+import { Play, Eye } from 'lucide-react'
+
+export function NextScheduledCard() {
+  return (
+    <div className="brand-gradient relative overflow-hidden rounded-3xl p-8">
+      <div className="relative z-10 flex flex-col items-center gap-8 md:flex-row">
+        <div className="h-48 w-48 shrink-0 overflow-hidden rounded-2xl bg-black/20 backdrop-blur-md">
+          <div className="flex h-full w-full items-center justify-center bg-surface-container-lowest/30">
+            <Play size={48} className="text-on-surface/50" />
+          </div>
+        </div>
+
+        <div className="flex-1">
+          <div className="mb-2 flex items-center gap-2">
+            <span className="rounded-full bg-black/20 px-3 py-1 text-xs font-bold uppercase tracking-widest text-on-surface">
+              Proximo agendado
+            </span>
+            <div className="h-2 w-2 animate-pulse rounded-full bg-on-surface" />
+          </div>
+          <h3 className="mb-2 text-3xl font-extrabold leading-tight text-on-surface">
+            Review de Gadgets 2024
+          </h3>
+          <p className="mb-6 font-medium text-on-surface/90">
+            Hoje as 18:00 — YouTube & Instagram Reels
+          </p>
+          <div className="flex gap-4">
+            <button
+              type="button"
+              className="cursor-pointer rounded-xl bg-on-surface px-6 py-3 font-bold text-background transition-transform hover:scale-105"
+            >
+              Editar Post
+            </button>
+            <button
+              type="button"
+              className="flex cursor-pointer items-center gap-2 rounded-xl border border-on-surface/20 bg-on-surface/10 px-6 py-3 font-bold text-on-surface backdrop-blur-md transition-all hover:bg-on-surface/20"
+            >
+              <Eye size={16} />
+              Ver Detalhes
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/modules/dashboard/application/components/performance-card.tsx
+++ b/src/modules/dashboard/application/components/performance-card.tsx
@@ -1,0 +1,56 @@
+import { Sparkles } from 'lucide-react'
+import type { PerformanceMetric } from '../types'
+
+const COLOR_MAP = {
+  primary: { bar: 'brand-gradient', text: 'text-primary' },
+  secondary: { bar: 'bg-secondary', text: 'text-secondary' },
+  tertiary: { bar: 'bg-tertiary', text: 'text-tertiary' },
+} as const
+
+interface PerformanceCardProps {
+  metrics: PerformanceMetric[]
+}
+
+export function PerformanceCard({ metrics }: Readonly<PerformanceCardProps>) {
+  return (
+    <div className="sticky top-28 rounded-3xl border border-outline-variant/15 bg-surface-container p-8">
+      <h4 className="mb-6 text-xl font-bold text-on-surface">Performance Semanal</h4>
+
+      <div className="space-y-8">
+        {metrics.map((metric) => {
+          const colors = COLOR_MAP[metric.color]
+          return (
+            <div key={metric.id} className="flex flex-col gap-2">
+              <div className="flex items-center justify-between text-sm">
+                <span className="text-on-surface-variant">{metric.label}</span>
+                <span className={`font-bold ${colors.text}`}>{metric.value}%</span>
+              </div>
+              <div className="h-2 overflow-hidden rounded-full bg-surface-container-lowest">
+                <div
+                  className={`h-full rounded-full ${colors.bar}`}
+                  style={{ width: `${metric.value}%` }}
+                />
+              </div>
+            </div>
+          )
+        })}
+      </div>
+
+      <div className="mt-12 border-t border-outline-variant/15 pt-8">
+        <div className="flex items-center gap-4 rounded-2xl bg-surface-container-low p-4">
+          <div className="flex h-12 w-12 shrink-0 items-center justify-center rounded-xl bg-tertiary/10">
+            <Sparkles size={20} className="text-tertiary" />
+          </div>
+          <div>
+            <p className="text-xs font-bold uppercase tracking-widest text-on-surface-variant">
+              Insights IA
+            </p>
+            <p className="text-sm font-medium leading-tight text-on-surface">
+              Postar as 19:30 hoje aumentara seu alcance em 15%.
+            </p>
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/modules/dashboard/application/components/quick-action-bar.tsx
+++ b/src/modules/dashboard/application/components/quick-action-bar.tsx
@@ -9,7 +9,7 @@ const ACTIONS = [
 
 export function QuickActionBar() {
   return (
-    <div className="fixed bottom-8 left-1/2 z-50 -translate-x-1/2">
+    <div className="fixed bottom-8 left-1/2 z-50 hidden -translate-x-1/2 md:block">
       <div className="glass ghost-border flex items-center gap-6 rounded-full px-6 py-3 shadow-2xl">
         {ACTIONS.map((action, i) => {
           const Icon = action.icon

--- a/src/modules/dashboard/application/components/quick-action-bar.tsx
+++ b/src/modules/dashboard/application/components/quick-action-bar.tsx
@@ -1,0 +1,37 @@
+import { PenSquare, CalendarDays, BarChart3, Zap } from 'lucide-react'
+
+const ACTIONS = [
+  { label: 'Rascunho', icon: PenSquare, colorClass: 'text-primary' },
+  { label: 'Calendario', icon: CalendarDays, colorClass: 'text-secondary' },
+  { label: 'Metricas', icon: BarChart3, colorClass: 'text-tertiary' },
+  { label: 'Comando', icon: Zap, colorClass: 'text-on-surface-variant' },
+] as const
+
+export function QuickActionBar() {
+  return (
+    <div className="fixed bottom-8 left-1/2 z-50 -translate-x-1/2">
+      <div className="glass ghost-border flex items-center gap-6 rounded-full px-6 py-3 shadow-2xl">
+        {ACTIONS.map((action, i) => {
+          const Icon = action.icon
+          return (
+            <div key={action.label} className="flex items-center gap-6">
+              {i > 0 && <div className="h-4 w-px bg-outline-variant" />}
+              <button
+                type="button"
+                className="group flex cursor-pointer items-center gap-2 rounded-lg px-3 py-1 transition-all hover:bg-surface-bright"
+              >
+                <Icon
+                  size={18}
+                  className={`${action.colorClass} transition-transform group-hover:scale-110`}
+                />
+                <span className="text-sm font-bold text-on-surface">
+                  {action.label}
+                </span>
+              </button>
+            </div>
+          )
+        })}
+      </div>
+    </div>
+  )
+}

--- a/src/modules/dashboard/application/components/recent-content-table.tsx
+++ b/src/modules/dashboard/application/components/recent-content-table.tsx
@@ -1,0 +1,94 @@
+import { MoreVertical, Image } from 'lucide-react'
+import type { RecentContent, ContentStatus } from '../types'
+
+const STATUS_STYLES: Record<ContentStatus, string> = {
+  published:
+    'bg-emerald-500/10 text-emerald-400 border-emerald-500/20',
+  scheduled:
+    'bg-primary/10 text-primary border-primary/20',
+  draft:
+    'bg-outline-variant/10 text-on-surface-variant border-outline-variant/20',
+}
+
+const STATUS_LABELS: Record<ContentStatus, string> = {
+  published: 'Publicado',
+  scheduled: 'Agendado',
+  draft: 'Rascunho',
+}
+
+interface RecentContentTableProps {
+  items: RecentContent[]
+}
+
+export function RecentContentTable({ items }: Readonly<RecentContentTableProps>) {
+  return (
+    <div className="space-y-6">
+      <div className="flex items-center justify-between">
+        <h4 className="text-xl font-bold text-on-surface">Conteudo Recente</h4>
+        <button
+          type="button"
+          className="cursor-pointer text-sm font-bold text-primary transition-colors hover:underline"
+        >
+          Ver Todos
+        </button>
+      </div>
+
+      <div className="overflow-hidden rounded-2xl border border-outline-variant/15 bg-surface-container">
+        <table className="w-full border-collapse text-left">
+          <thead>
+            <tr className="border-b border-outline-variant/15 bg-surface-container-high/50">
+              <th className="px-6 py-4 text-xs font-bold uppercase tracking-widest text-on-surface-variant">
+                Midia
+              </th>
+              <th className="px-6 py-4 text-xs font-bold uppercase tracking-widest text-on-surface-variant">
+                Status
+              </th>
+              <th className="hidden px-6 py-4 text-xs font-bold uppercase tracking-widest text-on-surface-variant sm:table-cell">
+                Data
+              </th>
+              <th className="px-6 py-4 text-right text-xs font-bold uppercase tracking-widest text-on-surface-variant">
+                Acoes
+              </th>
+            </tr>
+          </thead>
+          <tbody>
+            {items.map((item) => (
+              <tr
+                key={item.id}
+                className="group border-b border-outline-variant/10 last:border-b-0 transition-colors hover:bg-surface-bright"
+              >
+                <td className="px-6 py-4">
+                  <div className="flex items-center gap-3">
+                    <div className="flex h-10 w-10 shrink-0 items-center justify-center overflow-hidden rounded-lg bg-surface-container-highest">
+                      <Image size={16} className="text-on-surface-variant" />
+                    </div>
+                    <span className="font-medium text-on-surface">{item.title}</span>
+                  </div>
+                </td>
+                <td className="px-6 py-4">
+                  <span
+                    className={`rounded-full border px-3 py-1 text-xs font-bold ${STATUS_STYLES[item.status]}`}
+                  >
+                    {STATUS_LABELS[item.status]}
+                  </span>
+                </td>
+                <td className="hidden px-6 py-4 text-sm text-on-surface-variant sm:table-cell">
+                  {item.date}
+                </td>
+                <td className="px-6 py-4 text-right">
+                  <button
+                    type="button"
+                    aria-label={`Actions for ${item.title}`}
+                    className="cursor-pointer text-on-surface-variant transition-colors hover:text-on-surface"
+                  >
+                    <MoreVertical size={18} />
+                  </button>
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  )
+}

--- a/src/modules/dashboard/application/components/recent-content-table.tsx
+++ b/src/modules/dashboard/application/components/recent-content-table.tsx
@@ -78,7 +78,7 @@ export function RecentContentTable({ items }: Readonly<RecentContentTableProps>)
                 <td className="px-6 py-4 text-right">
                   <button
                     type="button"
-                    aria-label={`Actions for ${item.title}`}
+                    aria-label={`Acoes para ${item.title}`}
                     className="cursor-pointer text-on-surface-variant transition-colors hover:text-on-surface"
                   >
                     <MoreVertical size={18} />

--- a/src/modules/dashboard/application/components/stats-row.tsx
+++ b/src/modules/dashboard/application/components/stats-row.tsx
@@ -1,0 +1,43 @@
+import type { StatCard } from '../types'
+
+interface StatsRowProps {
+  stats: StatCard[]
+}
+
+function StatItem({ stat }: Readonly<{ stat: StatCard }>) {
+  const changeColor =
+    stat.change > 0
+      ? 'text-primary'
+      : stat.change < 0
+        ? 'text-error'
+        : 'text-on-surface-variant'
+
+  const changeLabel =
+    stat.change > 0
+      ? `+${stat.change}%`
+      : stat.change < 0
+        ? `${stat.change}%`
+        : '0%'
+
+  return (
+    <div className="rounded-2xl border border-outline-variant/15 bg-surface-container p-6 transition-colors hover:bg-surface-container-high">
+      <p className="mb-4 text-xs font-bold uppercase tracking-widest text-on-surface-variant">
+        {stat.label}
+      </p>
+      <div className="flex items-baseline gap-2">
+        <span className="text-4xl font-bold text-on-surface">{stat.value}</span>
+        <span className={`text-sm font-medium ${changeColor}`}>{changeLabel}</span>
+      </div>
+    </div>
+  )
+}
+
+export function StatsRow({ stats }: Readonly<StatsRowProps>) {
+  return (
+    <section className="grid grid-cols-1 gap-6 md:grid-cols-2 lg:grid-cols-4">
+      {stats.map((stat) => (
+        <StatItem key={stat.id} stat={stat} />
+      ))}
+    </section>
+  )
+}

--- a/src/modules/dashboard/application/components/welcome-hero.tsx
+++ b/src/modules/dashboard/application/components/welcome-hero.tsx
@@ -1,0 +1,12 @@
+export function WelcomeHero() {
+  return (
+    <section className="flex flex-col gap-2">
+      <h2 className="text-5xl font-bold tracking-tighter text-on-surface">
+        Bem-vindo, Robson
+      </h2>
+      <p className="text-lg leading-relaxed text-on-surface-variant">
+        Aqui esta o pulso criativo da sua rede hoje.
+      </p>
+    </section>
+  )
+}

--- a/src/modules/dashboard/application/mock-data.ts
+++ b/src/modules/dashboard/application/mock-data.ts
@@ -1,0 +1,38 @@
+import type { StatCard, RecentContent, PerformanceMetric } from './types'
+
+export const MOCK_STATS: StatCard[] = [
+  { id: 'total-posts', label: 'Total Posts', value: '128', change: 12 },
+  { id: 'engagement', label: 'Engajamento', value: '4.2k', change: 5 },
+  { id: 'published', label: 'Publicados', value: '85', change: -2 },
+  { id: 'platforms', label: 'Plataformas', value: '4', change: 0 },
+]
+
+export const MOCK_RECENT_CONTENT: RecentContent[] = [
+  {
+    id: '1',
+    title: 'Setup Gamer 2024',
+    status: 'published',
+    date: 'Ha 2 horas',
+    imageAlt: 'Macro shot of mechanical keyboard keys with blue backlight',
+  },
+  {
+    id: '2',
+    title: 'Vlog em Sao Paulo',
+    status: 'scheduled',
+    date: 'Amanha, 10:00',
+    imageAlt: 'Neon city lights reflected in a rainy window at night',
+  },
+  {
+    id: '3',
+    title: 'Dicas de Edicao',
+    status: 'draft',
+    date: 'Editado hoje',
+    imageAlt: 'Vintage camera and photography equipment on wooden table',
+  },
+]
+
+export const MOCK_PERFORMANCE: PerformanceMetric[] = [
+  { id: 'engagement', label: 'Engajamento Total', value: 82, color: 'primary' },
+  { id: 'followers', label: 'Crescimento de Seguidores', value: 65, color: 'secondary' },
+  { id: 'clicks', label: 'Taxa de Cliques', value: 48, color: 'tertiary' },
+]

--- a/src/modules/dashboard/application/types.ts
+++ b/src/modules/dashboard/application/types.ts
@@ -1,0 +1,29 @@
+export interface StatCard {
+  id: string
+  label: string
+  value: string
+  change: number
+}
+
+export interface ScheduledPost {
+  title: string
+  description: string
+  imageAlt: string
+}
+
+export type ContentStatus = 'published' | 'scheduled' | 'draft'
+
+export interface RecentContent {
+  id: string
+  title: string
+  status: ContentStatus
+  date: string
+  imageAlt: string
+}
+
+export interface PerformanceMetric {
+  id: string
+  label: string
+  value: number
+  color: 'primary' | 'secondary' | 'tertiary'
+}

--- a/src/modules/dashboard/application/types.ts
+++ b/src/modules/dashboard/application/types.ts
@@ -5,12 +5,6 @@ export interface StatCard {
   change: number
 }
 
-export interface ScheduledPost {
-  title: string
-  description: string
-  imageAlt: string
-}
-
 export type ContentStatus = 'published' | 'scheduled' | 'draft'
 
 export interface RecentContent {


### PR DESCRIPTION
## Summary

- Implement Dashboard page with welcome hero, stats cards, next scheduled post CTA, recent content table, weekly performance sidebar, and quick action bar
- Translate all hardcoded English text to Portuguese across create-content, brand-dna, and dashboard modules
- Fix content alignment on Create Content page (remove mx-auto)
- Add cursor-pointer to all dashboard buttons

## Components

| Component | Responsibility |
|---|---|
| `WelcomeHero` | Greeting with subtitle |
| `StatsRow` | 4 metric cards with % change |
| `NextScheduledCard` | Brand gradient CTA with next post |
| `RecentContentTable` | Table with thumbnails, status badges, dates |
| `PerformanceCard` | Sticky sidebar with 3 progress bars + AI insights |
| `QuickActionBar` | Floating glassmorphism bar with shortcuts |

## i18n: Portuguese translation

All user-facing text across 3 modules translated from English to Portuguese:
- **Create Content**: header, tabs labels already PT, input placeholder, buttons, tone options
- **Brand DNA**: page header, logo upload, color palette, typography, voice DNA, save bar, references, writing rules
- **Dashboard**: quick action bar labels

## Test plan

- [ ] Navigate to `/dashboard` — all components render
- [ ] Stats cards show values with colored % change
- [ ] Next scheduled card with gradient and action buttons
- [ ] Recent content table with status badges (Publicado/Agendado/Rascunho)
- [ ] Performance sidebar sticky with progress bars
- [ ] Quick action bar visible at bottom
- [ ] All buttons have cursor-pointer
- [ ] Navigate to `/create` — content aligned left, text in Portuguese
- [ ] Navigate to `/brand` — all text in Portuguese
- [ ] Verify light/dark mode across all pages
- [ ] Check mobile responsiveness
- [ ] Build passes: `npx next build`

Closes #10