### PR TITLE
fix: add html/body tags to root layout for Next.js 16

### DIFF
--- a/app/[locale]/layout.tsx
+++ b/app/[locale]/layout.tsx
@@ -1,13 +1,9 @@
 import { hasLocale, NextIntlClientProvider } from 'next-intl'
 import { getMessages } from 'next-intl/server'
-import { Inter, Manrope } from 'next/font/google'
 import { ThemeProvider } from 'next-themes'
 import { notFound } from 'next/navigation'
 import { routing } from '@/src/i18n/routing'
 import { QueryProvider, UserPreferencesEffect } from '@modules/shared'
-
-const inter = Inter({ variable: '--font-inter', subsets: ['latin'] })
-const manrope = Manrope({ variable: '--font-manrope', subsets: ['latin'] })
 
 export default async function LocaleLayout({
   children,
@@ -25,26 +21,18 @@ export default async function LocaleLayout({
   const messages = await getMessages()
 
   return (
-    <html
-      lang={locale}
-      className={`${inter.variable} ${manrope.variable} h-full antialiased`}
-      suppressHydrationWarning
+    <ThemeProvider
+      attribute="class"
+      defaultTheme="system"
+      enableSystem
+      disableTransitionOnChange
     >
-      <body className="min-h-full flex flex-col">
-        <ThemeProvider
-          attribute="class"
-          defaultTheme="system"
-          enableSystem
-          disableTransitionOnChange
-        >
-          <NextIntlClientProvider messages={messages}>
-            <QueryProvider>
-              <UserPreferencesEffect />
-              {children}
-            </QueryProvider>
-          </NextIntlClientProvider>
-        </ThemeProvider>
-      </body>
-    </html>
+      <NextIntlClientProvider messages={messages}>
+        <QueryProvider>
+          <UserPreferencesEffect />
+          {children}
+        </QueryProvider>
+      </NextIntlClientProvider>
+    </ThemeProvider>
   )
 }

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,5 +1,9 @@
 import type { Metadata } from 'next'
+import { Inter, Manrope } from 'next/font/google'
 import './globals.css'
+
+const inter = Inter({ variable: '--font-inter', subsets: ['latin'] })
+const manrope = Manrope({ variable: '--font-manrope', subsets: ['latin'] })
 
 export const metadata: Metadata = {
   title: 'Infinity Creators',
@@ -11,5 +15,12 @@ export default function RootLayout({
 }: Readonly<{
   children: React.ReactNode
 }>) {
-  return children
+  return (
+    <html
+      className={`${inter.variable} ${manrope.variable} h-full antialiased`}
+      suppressHydrationWarning
+    >
+      <body className="min-h-full flex flex-col">{children}</body>
+    </html>
+  )
 }


### PR DESCRIPTION
## Summary

- Moved `<html>` and `<body>` tags from `app/[locale]/layout.tsx` to `app/layout.tsx` (root layout)
- Next.js 16 requires these tags in the root layout — without them the app throws `Missing <html> and <body> tags in the root layout`
- Moved font declarations (Inter, Manrope) and global classes to root layout
- Locale layout now only handles providers (ThemeProvider, NextIntlClientProvider, QueryProvider)

## Test plan

- [ ] App loads without `Missing <html> and <body> tags` error
- [ ] Fonts render correctly (Inter, Manrope)
- [ ] Theme switching (dark/light) still works
- [ ] Locale routing works (`/pt-BR/...`, `/en/...`)